### PR TITLE
Simplify .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,3 @@ before_script: rethinkdb --daemon
 install:
   - mix local.hex --force
   - mix deps.get --only test
-script:
-  - mix test


### PR DESCRIPTION
Don't need the `mix test` in `.travis.yml`. That is the default