### PR TITLE
Keywords as opts

### DIFF
--- a/lib/rethinkdb/connection.ex
+++ b/lib/rethinkdb/connection.ex
@@ -72,6 +72,8 @@ defmodule RethinkDB.Connection do
       def stop do
         RethinkDB.Connection.stop(__MODULE__)
       end
+
+      defoverridable [ start_link: 1, start_link: 0 ]
     end
   end
 

--- a/lib/rethinkdb/query.ex
+++ b/lib/rethinkdb/query.ex
@@ -301,8 +301,8 @@ defmodule RethinkDB.Query do
   the result_format option, which checks the Content-Type of the response by 
   default.
   """
-  @spec http(Q.reql_string, Q.reql_obj) :: Q.t
-  def http(url, opts \\ %{}), do: %Q{query: [153, [url], opts]}
+  @spec http(Q.reql_string, Q.reql_opts) :: Q.t
+  operate_on_single_arg(:http, 153)
 
   @doc """
   Return a UUID (universally unique identifier), a string that can be used as a unique ID.
@@ -646,7 +646,7 @@ defmodule RethinkDB.Query do
 
   """
   @spec add([(Q.reql_number | Q.reql_string | Q.reql_array)]) :: Q.t
-  operate_on_list(:add, 24)
+  operate_on_list(:add, 24, opts: false)
 
   @doc """
   Subtract two numbers.
@@ -666,7 +666,7 @@ defmodule RethinkDB.Query do
 
   """
   @spec sub([Q.reql_number]) :: Q.t
-  operate_on_list(:sub, 25)
+  operate_on_list(:sub, 25, opts: false)
 
   @doc """
   Multiply two numbers, or make a periodic array.
@@ -688,7 +688,7 @@ defmodule RethinkDB.Query do
 
   """
   @spec mul([(Q.reql_number | Q.reql_array)]) :: Q.t
-  operate_on_list(:mul, 26)
+  operate_on_list(:mul, 26, opts: false)
 
   @doc """
   Divide two numbers.
@@ -707,7 +707,7 @@ defmodule RethinkDB.Query do
 
   """
   @spec divide([Q.reql_number]) :: Q.t
-  operate_on_list(:divide, 27)
+  operate_on_list(:divide, 27, opts: false)
 
   @doc """
   Find the remainder when dividing two numbers.
@@ -740,7 +740,7 @@ defmodule RethinkDB.Query do
       %RethinkDB.Record{data: false}
   """
   @spec and_r([Q.reql_bool]) :: Q.t
-  operate_on_list(:and_r, 67)
+  operate_on_list(:and_r, 67, opts: false)
 
   @doc """
   Compute the logical “or” of two values.
@@ -765,7 +765,7 @@ defmodule RethinkDB.Query do
 
   """
   @spec or_r([Q.reql_bool]) :: Q.t
-  operate_on_list(:or_r, 66)
+  operate_on_list(:or_r, 66, opts: false)
 
   @doc """
   Test if two values are equal.
@@ -788,7 +788,7 @@ defmodule RethinkDB.Query do
       %RethinkDB.Record{data: false}
   """
   @spec eq([Q.reql_datum]) :: Q.t
-  operate_on_list(:eq, 17)
+  operate_on_list(:eq, 17, opts: false)
     
   @doc """
   Test if two values are not equal.
@@ -811,7 +811,7 @@ defmodule RethinkDB.Query do
       %RethinkDB.Record{data: true}
   """
   @spec ne([Q.reql_datum]) :: Q.t
-  operate_on_list(:ne, 18)
+  operate_on_list(:ne, 18, opts: false)
 
   @doc """
   Test if one value is less than the other.
@@ -834,7 +834,7 @@ defmodule RethinkDB.Query do
       %RethinkDB.Record{data: true}
   """
   @spec lt([Q.reql_datum]) :: Q.t
-  operate_on_list(:lt, 19)
+  operate_on_list(:lt, 19, opts: false)
 
   @doc """
   Test if one value is less than or equal to the other.
@@ -857,7 +857,7 @@ defmodule RethinkDB.Query do
       %RethinkDB.Record{data: true}
   """
   @spec le([Q.reql_datum]) :: Q.t
-  operate_on_list(:le, 20)
+  operate_on_list(:le, 20, opts: false)
 
   @doc """
   Test if one value is greater than the other.
@@ -880,7 +880,7 @@ defmodule RethinkDB.Query do
       %RethinkDB.Record{data: true}
   """
   @spec gt([Q.reql_datum]) :: Q.t
-  operate_on_list(:gt, 21)
+  operate_on_list(:gt, 21, opts: false)
 
   @doc """
   Test if one value is greater than or equal to the other.
@@ -903,7 +903,7 @@ defmodule RethinkDB.Query do
       %RethinkDB.Record{data: true}
   """
   @spec ge([Q.reql_datum]) :: Q.t
-  operate_on_list(:ge, 22)
+  operate_on_list(:ge, 22, opts: false)
 
   @doc """
   Compute the logical inverse (not) of an expression.
@@ -913,7 +913,7 @@ defmodule RethinkDB.Query do
 
   """
   @spec not_r(Q.reql_bool) :: Q.t
-  operate_on_single_arg(:not_r, 23)
+  operate_on_single_arg(:not_r, 23, opts: false)
 
   @doc """
   Generate a random float between 0 and 1.
@@ -923,10 +923,10 @@ defmodule RethinkDB.Query do
 
   """
   @spec random :: Q.t
-  def random, do: %Q{query: [151, []]}
+  operate_on_zero_args(:random, 151, opts: false)
   @doc """
   Generate a random value in the range [0,upper). If upper is an integer then the
-  random value will be an interger. If upper is a float it will be a float.
+  random value will be an integer. If upper is a float it will be a float.
 
       iex> random(5) |> run conn
       %RethinkDB.Record{data: 3}
@@ -936,8 +936,9 @@ defmodule RethinkDB.Query do
 
   """
   @spec random(Q.reql_number) :: Q.t
-  def random(upper) when is_integer(upper), do: %Q{query: [151, [upper]]}
-  def random(upper) when is_float(upper), do: %Q{query: [151, [upper], %{float: true}]}
+  def random(upper) when is_float(upper), do: random(upper, float: true)
+  operate_on_single_arg(:random, 151)
+
   @doc """
   Generate a random value in the range [lower,upper). If either arg is an integer then the
   random value will be an interger. If one of them is a float it will be a float.
@@ -950,12 +951,10 @@ defmodule RethinkDB.Query do
 
   """
   @spec random(Q.reql_number, Q.reql_number) :: Q.t
-  def random(lower, upper) when is_integer(lower) and is_integer(upper) do
-    %Q{query: [151, [lower, upper]]}
-  end
   def random(lower, upper) when is_float(lower) or is_float(upper) do
-    %Q{query: [151, [lower, upper], %{float: true}]}
+    random(lower, upper, float: true)
   end
+  operate_on_two_args(:random, 151)
 
   @doc """
   Rounds the given value to the nearest whole integer.
@@ -963,19 +962,20 @@ defmodule RethinkDB.Query do
   For example, values of 1.0 up to but not including 1.5 will return 1.0, similar to floor; values of 1.5 up to 2.0 will return 2.0, similar to ceil.
   """
   @spec round_r(Q.reql_number) :: Q.t
-  operate_on_single_arg(:round_r, 185)
+  operate_on_single_arg(:round_r, 185, opts: false)
 
   @doc """
   Rounds the given value up, returning the smallest integer value greater than or equal to the given value (the value’s ceiling).
   """
   @spec ceil(Q.reql_number) :: Q.t
-  operate_on_single_arg(:ceil, 184)
+  operate_on_single_arg(:ceil, 184, opts: false)
 
   @doc """
   Rounds the given value down, returning the largest integer value less than or equal to the given value (the value’s floor).
   """
   @spec floor(Q.reql_number) :: Q.t
-  operate_on_single_arg(:floor, 183)
+  operate_on_single_arg(:floor, 183, opts: false)
+
   #
   #Selection Queries
   #
@@ -1154,9 +1154,7 @@ defmodule RethinkDB.Query do
   """
   @spec table_create(Q.t, Q.reql_string, Q.reql_opts) :: Q.t
   operate_on_single_arg(:table_create, 60)
-  def table_create(name, opt) when is_map(opt), do: %Q{query: [60, [wrap(name)], opt]}
   operate_on_two_args(:table_create, 60)
-  def table_create(db, name, opt) when is_map(opt), do: %Q{query: [60, [wrap(db), wrap(name)], opt]}
 
   @doc """
   Drop a table. The table and all its data will be deleted.
@@ -1171,15 +1169,15 @@ defmodule RethinkDB.Query do
   If the given table does not exist in the database, the command throws RqlRuntimeError.
   """
   @spec table_drop(Q.t, Q.reql_string) :: Q.t
-  operate_on_single_arg(:table_drop, 61)
-  operate_on_two_args(:table_drop, 61)
+  operate_on_single_arg(:table_drop, 61, opts: false)
+  operate_on_two_args(:table_drop, 61, opts: false)
 
   @doc """
   List all table names in a database. The result is a list of strings.
   """
   @spec table_list(Q.t) :: Q.t
-  operate_on_zero_args(:table_list, 62)
-  operate_on_single_arg(:table_list, 62)
+  operate_on_zero_args(:table_list, 62, opts: false)
+  operate_on_single_arg(:table_list, 62, opts: false)
 
   @doc """
   Create a new secondary index on a table. Secondary indexes improve the speed of 
@@ -1240,21 +1238,22 @@ defmodule RethinkDB.Query do
   indexes on this table if no indexes are specified.
   """
   @spec index_status(Q.t, Q.reql_string|Q.reql_array) :: Q.t
-  operate_on_single_arg(:index_status, 139)
+  operate_on_single_arg(:index_status, 139, opts: false)
   def index_status(table, indexes) when is_list(indexes) do
     %Q{query: [139, [wrap(table) | Enum.map(indexes, &wrap/1)]]}
   end
+  operate_on_two_args(:index_status, 139, opts: false)
 
   @doc """
   Wait for the specified indexes on this table to be ready, or for all indexes on 
   this table to be ready if no indexes are specified.
   """
   @spec index_wait(Q.t, Q.reql_string|Q.reql_array) :: Q.t
-  operate_on_single_arg(:index_wait, 140)
+  operate_on_single_arg(:index_wait, 140, opts: false)
   def index_wait(table, indexes) when is_list(indexes) do
     %Q{query: [140, [wrap(table) | Enum.map(indexes, &wrap/1)]]}
   end
-  operate_on_two_args(:index_wait, 140)
+  operate_on_two_args(:index_wait, 140, opts: false)
 
   #
   #Writing Data Queries

--- a/test/changes_test.exs
+++ b/test/changes_test.exs
@@ -128,7 +128,7 @@ defmodule ChangesTest do
   test "single document changefeed" do
     %RethinkDB.Record{data: %{"generated_keys" => [id]}} = table(@table_name)
                           |> insert(%{"test" => "value"}) |> run
-    q = table(@table_name) |> get(id) |> changes(%{include_initial: true})
+    q = table(@table_name) |> get(id) |> changes(include_initial: true)
     {:ok, _} = RethinkDB.Changefeed.start_link(
       TestChangefeed,
       {q,self},

--- a/test/connection_test.exs
+++ b/test/connection_test.exs
@@ -27,7 +27,7 @@ defmodule ConnectionTest do
   end
 
   test "reconnects if initial connect fails" do
-    {:ok, c} = start_link([port: 28014])
+    {:ok, c} = start_link(port: 28014)
     Process.unlink(c)
     %RethinkDB.Exception.ConnectionClosed{} = table_list |> run
     conn = FlakyConnection.start('localhost', 28015, [local_port: 28014])
@@ -42,7 +42,7 @@ defmodule ConnectionTest do
 
   test "replies to pending queries on disconnect" do
     conn = FlakyConnection.start('localhost', 28015)
-    {:ok, c} = start_link([port: conn.port])
+    {:ok, c} = start_link(port: conn.port)
     Process.unlink(c)
     table = "foo_flaky_test"
     RethinkDB.Query.table_create(table)|> run
@@ -81,7 +81,7 @@ defmodule ConnectionTest do
   end
 
   test "connection accepts default db" do
-    {:ok, c} = RethinkDB.Connection.start_link([db: "new_test"])
+    {:ok, c} = RethinkDB.Connection.start_link(db: "new_test")
     db_create("new_test") |> RethinkDB.run(c)
     db("new_test") |> table_create("new_test_table") |> RethinkDB.run(c)
     %{data: data} = table_list |> RethinkDB.run(c)
@@ -89,7 +89,7 @@ defmodule ConnectionTest do
   end
 
   test "connection accepts max_pending" do
-    {:ok, c} = RethinkDB.Connection.start_link([max_pending: 1])
+    {:ok, c} = RethinkDB.Connection.start_link(max_pending: 1)
     res = Enum.map(1..100, fn (_) ->
       Task.async fn ->
         now |> RethinkDB.run(c)
@@ -108,7 +108,7 @@ defmodule ConnectionTest do
 
   test "ssl connection" do
     conn = FlakyConnection.start('localhost', 28015, [ssl: [keyfile: "./test/cert/host.key", certfile: "./test/cert/host.crt"]])
-    {:ok, c} = RethinkDB.Connection.start_link([port: conn.port, ssl: [ca_certs: ["./test/cert/rootCA.crt"]], sync_connect: true])
+    {:ok, c} = RethinkDB.Connection.start_link(port: conn.port, ssl: [ca_certs: ["./test/cert/rootCA.crt"]], sync_connect: true)
     %{data: _} = table_list |> RethinkDB.run(c)
   end
 end
@@ -125,7 +125,7 @@ defmodule ConnectionRunTest do
 
   test "run(conn, opts) with :db option" do
     db_create("db_option_test") |> run
-    table_create("db_option_test_table") |> run([db: "db_option_test"])
+    table_create("db_option_test_table") |> run(db: "db_option_test")
 
     %{data: data} = db("db_option_test") |> table_list |> run
 
@@ -135,7 +135,7 @@ defmodule ConnectionRunTest do
   end
 
   test "run(conn, opts) with :durability option" do
-    response = table_create("durability_test_table") |> run([durability: "soft"])
+    response = table_create("durability_test_table") |> run(durability: "soft")
     durability = response.data["config_changes"]
                  |> List.first
                  |> Map.fetch!("new_val")
@@ -147,12 +147,12 @@ defmodule ConnectionRunTest do
   end
 
   test "run with :noreply option" do
-    :ok = make_array([1,2,3]) |> run(%{noreply: true})
+    :ok = make_array([1,2,3]) |> run(noreply: true)
     noreply_wait 
   end
 
   test "run with :profile options" do
-    resp = make_array([1,2,3]) |> run(%{profile: true})
+    resp = make_array([1,2,3]) |> run(profile: true)
     assert [%{"description" => _, "duration(ms)" => _,
              "sub_tasks" => _}] = resp.profile
   end

--- a/test/query/date_time_test.exs
+++ b/test/query/date_time_test.exs
@@ -33,7 +33,7 @@ defmodule DateTimeTest do
     %Record{data: data} = iso8601("1970-01-01T00:00:00+00:00") |> run
     assert data.epoch_time == 0
     assert data.timezone == "+00:00"
-    %Record{data: data} = iso8601("1970-01-01T00:00:00", %{"default_timezone" => "+01:00"}) |> run
+    %Record{data: data} = iso8601("1970-01-01T00:00:00", default_timezone: "+01:00") |> run
     assert data.epoch_time == -3600
     assert data.timezone == "+01:00"
   end

--- a/test/query/geospatial_adv_test.exs
+++ b/test/query/geospatial_adv_test.exs
@@ -9,7 +9,7 @@ defmodule GeospatialAdvTest do
   setup_all do
     start_link
     table_create(@table_name) |> run
-    table(@table_name) |> index_create("location", %{geo: true}) |> run
+    table(@table_name) |> index_create("location", geo: true) |> run
     table(@table_name) |> index_wait("location") |> run
     on_exit fn ->
       start_link
@@ -31,8 +31,7 @@ defmodule GeospatialAdvTest do
       %{location: point(0.001,0)}
     ) |> run
     %{data: data} = table(@table_name) |> get_intersecting(
-      circle({0,0}, 5000),
-      %{index: "location"}
+      circle({0,0}, 5000), index: "location"
     ) |> run
     points = for x <- data, do: x["location"].coordinates
     assert Enum.sort(points) == [{0.001, 0}, {0.001,0.001}]
@@ -46,8 +45,7 @@ defmodule GeospatialAdvTest do
       %{location: point(0.001,0)}
     ) |> run
     %Record{data: data} = table(@table_name) |> get_nearest(
-      point({0,0}),
-      %{index: "location", max_dist: 5000000}
+      point({0,0}), index: "location", max_dist: 5000000
     ) |> run
     assert Enum.count(data) == 2
   end

--- a/test/query/joins_test.exs
+++ b/test/query/joins_test.exs
@@ -56,7 +56,7 @@ defmodule JoinsTest do
     table_create("test_2") |> run
     table("test_1") |> insert([%{id: 3, a: 1, b: 2}, %{id: 2, a: 2, b: 3}]) |> run
     table("test_2") |> insert([%{id: 1, c: 4}]) |> run
-    q = eq_join(table("test_1"), :a, table("test_2"), %{index: :id})
+    q = eq_join(table("test_1"), :a, table("test_2"), index: :id)
     %Collection{data: data} = run q
     %Collection{data: data2} = q |> zip |> run
     table_drop("test_1") |> run

--- a/test/query/selection_test.exs
+++ b/test/query/selection_test.exs
@@ -45,7 +45,7 @@ defmodule SelectionTest do
     table(@table_name) |> insert(%{id: "b", other_id: "d"}) |> run
     table(@table_name) |> index_create("other_id") |> run
     table(@table_name) |> index_wait("other_id") |> run
-    data = table(@table_name) |> get_all(["c", "d"], %{index: "other_id"}) |> run
+    data = table(@table_name) |> get_all(["c", "d"], index: "other_id") |> run
     assert Enum.sort(Enum.to_list(data)) == [
       %{"id" => "a", "other_id" => "c"},
       %{"id" => "b", "other_id" => "d"}

--- a/test/query/table_db_test.exs
+++ b/test/query/table_db_test.exs
@@ -33,7 +33,7 @@ defmodule TableDBTest do
     %Record{data: tables} = run q
     assert !Enum.member?(tables, @table_name)
 
-    q = db(@db_name) |> table_create(@table_name, %{primary_key: "not_id"})
+    q = db(@db_name) |> table_create(@table_name, primary_key: "not_id")
     %Record{data: result} = run q
     %{"config_changes" => [%{"new_val" => %{"primary_key" => primary_key}}]} = result
     assert primary_key == "not_id"

--- a/test/query/table_index_test.exs
+++ b/test/query/table_index_test.exs
@@ -21,12 +21,12 @@ defmodule TableIndexTest do
   test "indexes" do
     %Record{data: data} = table(@table_name) |> index_create("hello") |> run
     assert data == %{"created" => 1}
-    %Record{data: data} = table(@table_name) |> index_wait(["hello"]) |> run
+    %Record{data: data} = table(@table_name) |> index_wait("hello") |> run
     assert [
       %{"function" => _, "geo" => false, "index" => "hello",
         "multi" => false, "outdated" => false,"ready" => true}
       ] = data
-    %Record{data: data} = table(@table_name) |> index_status(["hello"]) |> run
+    %Record{data: data} = table(@table_name) |> index_status("hello") |> run
     assert [
       %{"function" => _, "geo" => false, "index" => "hello",
         "multi" => false, "outdated" => false,"ready" => true}

--- a/test/query/table_test.exs
+++ b/test/query/table_test.exs
@@ -30,7 +30,7 @@ defmodule TableTest do
     %Record{data: tables} = run q
     assert !Enum.member?(tables, @table_name)
 
-    q = table_create(@table_name, %{primary_key: "not_id"})
+    q = table_create(@table_name, primary_key: "not_id")
     %Record{data: result} = run q
     %{"config_changes" => [%{"new_val" => %{"primary_key" => primary_key}}]} = result
     assert primary_key == "not_id"


### PR DESCRIPTION
* Cherry-picking your commits from the `keywords_as_opts` branch.
* Small changes to `index_status()`, `index_wait()` and `http()` functions.
* Use `Keyword` instead of the deprecated `Dict` in `lib/query/macro.ex`.
* Adapt tests to pass keywords instead of map options.

This fixes #66 without breaking anything with `%{}` options.

Not sure why your `make overridable` commit is in my pull request :confused:.