### PR TITLE
updating poison to 3.x (#137)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule RethinkDB.Mixfile do use Mix.Project
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:poison, "~> 1.5 or ~> 2.0"},
+      {:poison, "~> 3.0"},
       {:earmark, "~> 0.1", only: :dev},
       {:ex_doc, "~> 0.7", only: :dev},
       {:flaky_connection, github: "hamiltop/flaky_connection", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -11,6 +11,6 @@
   "inch_ex": {:hex, :inch_ex, "0.2.4"},
   "jsx": {:hex, :jsx, "2.6.2", "213721e058da0587a4bce3cc8a00ff6684ced229c8f9223245c6ff2c88fbaa5a", [:mix, :rebar], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
-  "poison": {:hex, :poison, "2.0.1", "81248a36d1b602b17ea6556bfa8952492091f01af05173de11f8b297e2bbf088", [:mix], []},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "ranch": {:hex, :ranch, "1.1.0", "f7ed6d97db8c2a27cca85cacbd543558001fc5a355e93a7bff1e9a9065a8545b", [:make], []},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5", "2e73e068cd6393526f9fa6d399353d7c9477d6886ba005f323b592d389fb47be", [:make], []}}


### PR DESCRIPTION
1) I had failing tests on master around SSL and genservers.  The PR does not add any new failures from those initial ones.

2) Upgrading to just poison 3.x instead of having multiple old versions.